### PR TITLE
Shift time on splitting *.srt optionally (default: true)

### DIFF
--- a/spec/srt_spec.rb
+++ b/spec/srt_spec.rb
@@ -7,7 +7,7 @@ describe SRT do
       let(:line) { SRT::Line.new }
       
       it "should create an empty subtitle" do
-        expect(line).to be_empty
+        line.should be_empty
       end      
     end
 
@@ -20,7 +20,7 @@ describe SRT do
       end
 
       it "should produce timecodes that match the internal float values" do
-        expect(line.time_str).to eq("00:03:44,200 --> 00:04:04,578")
+        line.time_str.should eq("00:03:44,200 --> 00:04:04,578")
       end      
     end
   end
@@ -28,58 +28,58 @@ describe SRT do
   describe SRT::File do
     describe ".parse_timecode" do
       it "should convert the SRT timecode format to a float representing seconds" do
-        expect(SRT::File.parse_timecode("01:03:44,200")).to eq(3824.2)
+        SRT::File.parse_timecode("01:03:44,200").should eq(3824.2)
       end
     end
 
     describe ".parse_timespan" do
       it "should convert a timespan string ([+|-][amount][h|m|s|mil]) to a float representing seconds" do
-        expect(SRT::File.parse_timespan("-3.5m")).to eq(-210)
+        SRT::File.parse_timespan("-3.5m").should eq(-210)
       end
     end
 
     describe ".parse_framerate" do
       it "should convert a framerate string ([number]fps) to a float representing seconds" do
-        expect(SRT::File.parse_framerate("23.976fps")).to eq(23.976)
+        SRT::File.parse_framerate("23.976fps").should eq(23.976)
       end
     end    
 
     shared_examples_for "an SRT file" do
       context "when parsing a properly formatted BSG SRT file" do
         it "should return an SRT::File" do
-          expect(subject.class).to eq(SRT::File)
+          subject.class.should eq(SRT::File)
         end
         
         it "should have 600 lines" do
-          expect(subject.lines.size).to eq(600)
+          subject.lines.size.should eq(600)
         end
 
         it "should have no errors" do
-          expect(subject.errors).to be_empty
+          subject.errors.should be_empty
         end
 
         it "should have the expected sequence number on the first subtitle" do
-          expect(subject.lines.first.sequence).to eq(1)
+          subject.lines.first.sequence.should eq(1)
         end
 
         it "should have the expected timecodes on the first subtitle" do
-          expect(subject.lines.first.time_str).to eq("00:00:02,110 --> 00:00:04,578")
+          subject.lines.first.time_str.should eq("00:00:02,110 --> 00:00:04,578")
         end
 
         it "should have the expected text on the first subtitle" do
-          expect(subject.lines.first.text).to eq(["<i>(male narrator) Previously", "on Battlestar Galactica.</i>"])
+          subject.lines.first.text.should eq(["<i>(male narrator) Previously", "on Battlestar Galactica.</i>"])
         end
 
         it "should have the expected sequence number on the last subtitle" do
-          expect(subject.lines.last.sequence).to eq(600)
+          subject.lines.last.sequence.should eq(600)
         end
 
         it "should have the expected timecodes on the last subtitle" do
-          expect(subject.lines.last.time_str).to eq("00:43:26,808 --> 00:43:28,139")
+          subject.lines.last.time_str.should eq("00:43:26,808 --> 00:43:28,139")
         end
 
         it "should have the expected text on the last subtitle" do
-          expect(subject.lines.last.text).to eq(["Thank you."])
+          subject.lines.last.text.should eq(["Thank you."])
         end
       end
     end
@@ -89,15 +89,15 @@ describe SRT do
         let(:file) { SRT::File.parse(File.open("./spec/wotw-dubious.srt")) }
 
         it "should parse" do
-          expect(file.class).to eq(SRT::File)
+          file.class.should eq(SRT::File)
         end
 
         it "should have 1123 lines" do
-          expect(file.lines.size).to eq(1123)
+          file.lines.size.should eq(1123)
         end
 
         it "should have no errors" do
-          expect(file.errors).to be_empty
+          file.errors.should be_empty
         end
       end      
 
@@ -105,23 +105,23 @@ describe SRT do
         let(:file) { SRT::File.parse(File.open("./spec/coordinates-dummy.srt")) }
 
         it "should return an SRT::File" do
-          expect(file.class).to eq(SRT::File)
+          file.class.should eq(SRT::File)
         end
         
         it "should have 3 lines" do
-          expect(file.lines.size).to eq(3)
+          file.lines.size.should eq(3)
         end
 
         it "should have no errors" do
-          expect(file.errors).to be_empty
+          file.errors.should be_empty
         end
 
         it "should have the expected display coordinates on the first subtitle" do
-          expect(file.lines.first.display_coordinates).to eq("X1:100 X2:600 Y1:1 Y2:4")
+          file.lines.first.display_coordinates.should eq("X1:100 X2:600 Y1:1 Y2:4")
         end
 
         it "should have the expected display coordinates on the last subtitle" do 
-          expect(file.lines.last.display_coordinates).to eq("X1:1 X2:333 Y1:50 Y2:29")
+          file.lines.last.display_coordinates.should eq("X1:1 X2:333 Y1:50 Y2:29")
         end
       end
     end
@@ -145,19 +145,19 @@ describe SRT do
           before { part1.append({ "00:53:57,241" => part2 }) }
 
           it "should have grown to 808 subtitles" do
-            expect(part1.lines.length).to eq(808)
+            part1.lines.length.should eq(808)
           end
 
           it "should have appended subtitles starting with sequence number 448" do
-            expect(part1.lines[447].sequence).to eq(448)
+            part1.lines[447].sequence.should eq(448)
           end         
 
           it "should have appended subtitles ending with sequence number 808" do
-            expect(part1.lines.last.sequence).to eq(808)
+            part1.lines.last.sequence.should eq(808)
           end
 
           it "should have appended subtitles relatively from 00:53:57,241" do
-            expect(part1.lines[447].time_str).to eq("00:54:02,152 --> 00:54:04,204")
+            part1.lines[447].time_str.should eq("00:54:02,152 --> 00:54:04,204")
           end          
         end
 
@@ -165,7 +165,7 @@ describe SRT do
           before { part1.append({ "+7.241s" => part2 }) }
           
           it "should have appended subtitles relatively from +7.241s after the previously last subtitle" do
-            expect(part1.lines[447].time_str).to eq("00:54:02,283 --> 00:54:04,335")
+            part1.lines[447].time_str.should eq("00:54:02,283 --> 00:54:04,335")
           end
         end
       end
@@ -179,29 +179,59 @@ describe SRT do
           let(:result) { file.split( :at => "00:19:24,500" ) }
 
           it "should return an array containing two SRT::File instances" do
-            expect(result.length).to eq(2)
-            expect(result[0].class).to eq(SRT::File)
-            expect(result[1].class).to eq(SRT::File)
+            result.length.should eq(2)
+            result[0].class.should eq(SRT::File)
+            result[1].class.should eq(SRT::File)
           end
 
           it "should include a subtitle that overlaps a splitting point in the first file" do
-            expect(result[0].lines.last.text).to eq(["I'll see you guys in combat."])
+            result[0].lines.last.text.should eq(["I'll see you guys in combat."])
           end
 
           it "should make an overlapping subtitle end at the splitting point in the first file" do
-            expect(result[0].lines.last.time_str).to eq("00:19:23,901 --> 00:19:24,500")
+            result[0].lines.last.time_str.should eq("00:19:23,901 --> 00:19:24,500")
           end
 
           it "should include a subtitle that overlaps a splitting point in the second file as well" do
-            expect(result[1].lines.first.text).to eq(["I'll see you guys in combat."])
+            result[1].lines.first.text.should eq(["I'll see you guys in combat."])
           end
 
           it "should make an overlapping subtitle remain at the beginning in the second file" do
-            expect(result[1].lines.first.time_str).to eq("00:00:00,000 --> 00:00:01,528")
+            result[1].lines.first.time_str.should eq("00:00:00,000 --> 00:00:01,528")
           end
 
           it "should shift back all timecodes of the second file relative to the new file beginning" do
-            expect(result[1].lines[1].time_str).to eq("00:00:01,737 --> 00:00:03,466")
+            result[1].lines[1].time_str.should eq("00:00:01,737 --> 00:00:03,466")
+          end
+        end
+
+        context "when passing { :at => \"00:19:24,500\", :shift_time => false }" do
+          let(:result) { file.split( :at => "00:19:24,500", :shift_time => false ) }
+
+          it "should return an array containing two SRT::File instances" do
+            result.length.should eq(2)
+            result[0].class.should eq(SRT::File)
+            result[1].class.should eq(SRT::File)
+          end
+
+          it "should include a subtitle that overlaps a splitting point in the first file" do
+            result[0].lines.last.text.should eq(["I'll see you guys in combat."])
+          end
+
+          it "should not make an overlapping subtitle end at the splitting point in the first file" do
+            result[0].lines.last.time_str.should eq("00:19:23,901 --> 00:19:26,028")
+          end
+
+          it "should include a subtitle that overlaps a splitting point in the second file as well" do
+            result[1].lines.first.text.should eq(["I'll see you guys in combat."])
+          end
+
+          it "should not make an overlapping subtitle remain at the beginning in the second file" do
+            result[1].lines.first.time_str.should eq("00:19:23,901 --> 00:19:26,028")
+          end
+
+          it "should not shift back timecodes of the second file relative to the new file beginning" do
+            result[1].lines[1].time_str.should eq("00:19:26,237 --> 00:19:27,966")
           end
         end
       
@@ -209,31 +239,31 @@ describe SRT do
           let(:result) { file.split( :at => ["00:15:00,000", "00:30:00,000"] ) }
 
           it "should return an array containing three SRT::File instances" do
-            expect(result.length).to eq(3)
-            expect(result[0].class).to eq(SRT::File)
-            expect(result[1].class).to eq(SRT::File)
-            expect(result[2].class).to eq(SRT::File)
+            result.length.should eq(3)
+            result[0].class.should eq(SRT::File)
+            result[1].class.should eq(SRT::File)
+            result[2].class.should eq(SRT::File)
           end
 
           it "should let subtitles start at sequence number #1 in all three files" do
-            expect(result[0].lines.first.sequence).to eq(1)
-            expect(result[1].lines.first.sequence).to eq(1)
-            expect(result[2].lines.first.sequence).to eq(1)
+            result[0].lines.first.sequence.should eq(1)
+            result[1].lines.first.sequence.should eq(1)
+            result[2].lines.first.sequence.should eq(1)
           end
 
           it "should put 176 subtitles in the first file" do
-            expect(result[0].lines.length).to eq(176)
-            expect(result[0].lines.last.sequence).to eq(176)
+            result[0].lines.length.should eq(176)
+            result[0].lines.last.sequence.should eq(176)
           end
 
           it "should put 213 subtitles in the second file" do
-            expect(result[1].lines.length).to eq(213)
-            expect(result[1].lines.last.sequence).to eq(213)
+            result[1].lines.length.should eq(213)
+            result[1].lines.last.sequence.should eq(213)
           end
 
           it "should put 212 subtitles in the third file" do
-            expect(result[2].lines.length).to eq(212)
-            expect(result[2].lines.last.sequence).to eq(212)
+            result[2].lines.length.should eq(212)
+            result[2].lines.last.sequence.should eq(212)
           end         
         end
       end
@@ -247,11 +277,11 @@ describe SRT do
           before { file.timeshift({ :all => "+2.5s" }) }
 
           it "should have timecodes shifted forward by 2.5s for subtitle #24" do
-            expect(file.lines[23].time_str).to eq("00:01:59,291 --> 00:02:00,815")
+            file.lines[23].time_str.should eq("00:01:59,291 --> 00:02:00,815")
           end
 
           it "should have timecodes shifted forward by 2.5s for subtitle #43" do
-            expect(file.lines[42].time_str).to eq("00:03:46,164 --> 00:03:47,631")
+            file.lines[42].time_str.should eq("00:03:46,164 --> 00:03:47,631")
           end
         end
 
@@ -259,11 +289,11 @@ describe SRT do
           before { file.timeshift({ "25fps" => "23.976fps" }) }
 
           it "should have correctly scaled timecodes for subtitle #24" do
-            expect(file.lines[23].time_str).to eq("00:01:52,007 --> 00:01:53,469")
+            file.lines[23].time_str.should eq("00:01:52,007 --> 00:01:53,469")
           end
           
           it "should have correctly scaled timecodes for subtitle #43" do
-            expect(file.lines[42].time_str).to eq("00:03:34,503 --> 00:03:35,910")
+            file.lines[42].time_str.should eq("00:03:34,503 --> 00:03:35,910")
           end
         end
 
@@ -271,11 +301,11 @@ describe SRT do
           before { file.timeshift({ 24 => "00:03:53,582", 43 => "00:14:54,656" }) }
 
           it "should have shifted timecodes for subtitle #24" do
-            expect(file.lines[23].time_str).to eq("00:03:53,582 --> 00:04:03,009")
+            file.lines[23].time_str.should eq("00:03:53,582 --> 00:04:03,009")
           end
           
           it "should have differently shifted timecodes for subtitle #43" do
-            expect(file.lines[42].time_str).to eq("00:14:54,656 --> 00:15:03,730")
+            file.lines[42].time_str.should eq("00:14:54,656 --> 00:15:03,730")
           end
         end
       end
@@ -302,7 +332,7 @@ you're a machine.
 00:00:07,014 --> 00:00:08,003
 The robot.
 END
-            expect(file.to_s).to eq(OUTPUT)
+            file.to_s.should eq(OUTPUT)
           end
         end
       end


### PR DESCRIPTION
Sometimes you need not to shift timecodes when the srt file is split, e.g. if you're implementing something like video chapters. In this pull request I added this possibility and it could be used as simple as it is:

``` ruby
 SRT::File.parse(my_srt_file).split at: '00:19:24,500', shift_time: false
```
