### PR TITLE
Convert specs to RSpec 3.0.3 syntax with Transpec

### DIFF
--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -5,14 +5,14 @@ describe SRT::File do
   describe '#parse' do
     context "parsing with debug true" do
       it "should be verbose when failing" do
-        $stderr.should_receive(:puts).once
-        SRT::File.parse(File.open("./spec/fixtures/invalid.srt"), debug: true).errors.should_not be_empty
+        expect($stderr).to receive(:puts).once
+        expect(SRT::File.parse(File.open("./spec/fixtures/invalid.srt"), debug: true).errors).not_to be_empty
       end
     end
     context "parsing with debug false" do
       it "should raise exception silently" do
-        $stderr.should_not_receive(:puts)
-        SRT::File.parse(File.open("./spec/fixtures/invalid.srt")).errors.should_not be_empty
+        expect($stderr).not_to receive(:puts)
+        expect(SRT::File.parse(File.open("./spec/fixtures/invalid.srt")).errors).not_to be_empty
       end
     end
   end
@@ -20,39 +20,39 @@ describe SRT::File do
   shared_examples_for "an SRT file" do
     context "when parsing a properly formatted BSG SRT file" do
       it "should return an SRT::File" do
-        subject.class.should eq(SRT::File)
+        expect(subject.class).to eq(SRT::File)
       end
 
       it "should have 600 lines" do
-        subject.lines.size.should eq(600)
+        expect(subject.lines.size).to eq(600)
       end
 
       it "should have no errors" do
-        subject.errors.should be_empty
+        expect(subject.errors).to be_empty
       end
 
       it "should have the expected sequence number on the first subtitle" do
-        subject.lines.first.sequence.should eq(1)
+        expect(subject.lines.first.sequence).to eq(1)
       end
 
       it "should have the expected timecodes on the first subtitle" do
-        subject.lines.first.time_str.should eq("00:00:02,110 --> 00:00:04,578")
+        expect(subject.lines.first.time_str).to eq("00:00:02,110 --> 00:00:04,578")
       end
 
       it "should have the expected text on the first subtitle" do
-        subject.lines.first.text.should eq(["<i>(male narrator) Previously", "on Battlestar Galactica.</i>"])
+        expect(subject.lines.first.text).to eq(["<i>(male narrator) Previously", "on Battlestar Galactica.</i>"])
       end
 
       it "should have the expected sequence number on the last subtitle" do
-        subject.lines.last.sequence.should eq(600)
+        expect(subject.lines.last.sequence).to eq(600)
       end
 
       it "should have the expected timecodes on the last subtitle" do
-        subject.lines.last.time_str.should eq("00:43:26,808 --> 00:43:28,139")
+        expect(subject.lines.last.time_str).to eq("00:43:26,808 --> 00:43:28,139")
       end
 
       it "should have the expected text on the last subtitle" do
-        subject.lines.last.text.should eq(["Thank you."])
+        expect(subject.lines.last.text).to eq(["Thank you."])
       end
     end
   end
@@ -62,15 +62,15 @@ describe SRT::File do
       let(:file) { SRT::File.parse(File.open("./spec/fixtures/wotw-dubious.srt")) }
 
       it "should parse" do
-        file.class.should eq(SRT::File)
+        expect(file.class).to eq(SRT::File)
       end
 
       it "should have 1123 lines" do
-        file.lines.size.should eq(1123)
+        expect(file.lines.size).to eq(1123)
       end
 
       it "should have no errors" do
-        file.errors.should be_empty
+        expect(file.errors).to be_empty
       end
     end
 
@@ -78,23 +78,23 @@ describe SRT::File do
       let(:file) { SRT::File.parse(File.open("./spec/fixtures/coordinates-dummy.srt")) }
 
       it "should return an SRT::File" do
-        file.class.should eq(SRT::File)
+        expect(file.class).to eq(SRT::File)
       end
 
       it "should have 3 lines" do
-        file.lines.size.should eq(3)
+        expect(file.lines.size).to eq(3)
       end
 
       it "should have no errors" do
-        file.errors.should be_empty
+        expect(file.errors).to be_empty
       end
 
       it "should have the expected display coordinates on the first subtitle" do
-        file.lines.first.display_coordinates.should eq("X1:100 X2:600 Y1:1 Y2:4")
+        expect(file.lines.first.display_coordinates).to eq("X1:100 X2:600 Y1:1 Y2:4")
       end
 
       it "should have the expected display coordinates on the last subtitle" do
-        file.lines.last.display_coordinates.should eq("X1:1 X2:333 Y1:50 Y2:29")
+        expect(file.lines.last.display_coordinates).to eq("X1:1 X2:333 Y1:50 Y2:29")
       end
     end
   end
@@ -118,19 +118,19 @@ describe SRT::File do
         before { part1.append({ "00:53:57,241" => part2 }) }
 
         it "should have grown to 808 subtitles" do
-          part1.lines.length.should eq(808)
+          expect(part1.lines.length).to eq(808)
         end
 
         it "should have appended subtitles starting with sequence number 448" do
-          part1.lines[447].sequence.should eq(448)
+          expect(part1.lines[447].sequence).to eq(448)
         end
 
         it "should have appended subtitles ending with sequence number 808" do
-          part1.lines.last.sequence.should eq(808)
+          expect(part1.lines.last.sequence).to eq(808)
         end
 
         it "should have appended subtitles relatively from 00:53:57,241" do
-          part1.lines[447].time_str.should eq("00:54:02,152 --> 00:54:04,204")
+          expect(part1.lines[447].time_str).to eq("00:54:02,152 --> 00:54:04,204")
         end
       end
 
@@ -138,7 +138,7 @@ describe SRT::File do
         before { part1.append({ "+7.241s" => part2 }) }
 
         it "should have appended subtitles relatively from +7.241s after the previously last subtitle" do
-          part1.lines[447].time_str.should eq("00:54:02,283 --> 00:54:04,335")
+          expect(part1.lines[447].time_str).to eq("00:54:02,283 --> 00:54:04,335")
         end
       end
     end
@@ -152,29 +152,29 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500" ) }
 
         it "should return an array containing two SRT::File instances" do
-          result.length.should eq(2)
-          result[0].class.should eq(SRT::File)
-          result[1].class.should eq(SRT::File)
+          expect(result.length).to eq(2)
+          expect(result[0].class).to eq(SRT::File)
+          expect(result[1].class).to eq(SRT::File)
         end
 
         it "should include a subtitle that overlaps a splitting point in the first file" do
-          result[0].lines.last.text.should eq(["I'll see you guys in combat."])
+          expect(result[0].lines.last.text).to eq(["I'll see you guys in combat."])
         end
 
         it "should make an overlapping subtitle end at the splitting point in the first file" do
-          result[0].lines.last.time_str.should eq("00:19:23,901 --> 00:19:24,500")
+          expect(result[0].lines.last.time_str).to eq("00:19:23,901 --> 00:19:24,500")
         end
 
         it "should include a subtitle that overlaps a splitting point in the second file as well" do
-          result[1].lines.first.text.should eq(["I'll see you guys in combat."])
+          expect(result[1].lines.first.text).to eq(["I'll see you guys in combat."])
         end
 
         it "should make an overlapping subtitle remain at the beginning in the second file" do
-          result[1].lines.first.time_str.should eq("00:00:00,000 --> 00:00:01,528")
+          expect(result[1].lines.first.time_str).to eq("00:00:00,000 --> 00:00:01,528")
         end
 
         it "should shift back all timecodes of the second file relative to the new file beginning" do
-          result[1].lines[1].time_str.should eq("00:00:01,737 --> 00:00:03,466")
+          expect(result[1].lines[1].time_str).to eq("00:00:01,737 --> 00:00:03,466")
         end
       end
 
@@ -182,29 +182,29 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :timeshift => false ) }
 
         it "should return an array containing two SRT::File instances" do
-          result.length.should eq(2)
-          result[0].class.should eq(SRT::File)
-          result[1].class.should eq(SRT::File)
+          expect(result.length).to eq(2)
+          expect(result[0].class).to eq(SRT::File)
+          expect(result[1].class).to eq(SRT::File)
         end
 
         it "should include a subtitle that overlaps a splitting point in the first file" do
-          result[0].lines.last.text.should eq(["I'll see you guys in combat."])
+          expect(result[0].lines.last.text).to eq(["I'll see you guys in combat."])
         end
 
         it "should not make an overlapping subtitle end at the splitting point in the first file" do
-          result[0].lines.last.time_str.should eq("00:19:23,901 --> 00:19:26,028")
+          expect(result[0].lines.last.time_str).to eq("00:19:23,901 --> 00:19:26,028")
         end
 
         it "should include a subtitle that overlaps a splitting point in the second file as well" do
-          result[1].lines.first.text.should eq(["I'll see you guys in combat."])
+          expect(result[1].lines.first.text).to eq(["I'll see you guys in combat."])
         end
 
         it "should not make an overlapping subtitle remain at the beginning in the second file" do
-          result[1].lines.first.time_str.should eq("00:19:23,901 --> 00:19:26,028")
+          expect(result[1].lines.first.time_str).to eq("00:19:23,901 --> 00:19:26,028")
         end
 
         it "should not shift back timecodes of the second file relative to the new file beginning" do
-          result[1].lines[1].time_str.should eq("00:19:26,237 --> 00:19:27,966")
+          expect(result[1].lines[1].time_str).to eq("00:19:26,237 --> 00:19:27,966")
         end
       end
 
@@ -212,31 +212,31 @@ describe SRT::File do
         let(:result) { file.split( :at => ["00:15:00,000", "00:30:00,000"] ) }
 
         it "should return an array containing three SRT::File instances" do
-          result.length.should eq(3)
-          result[0].class.should eq(SRT::File)
-          result[1].class.should eq(SRT::File)
-          result[2].class.should eq(SRT::File)
+          expect(result.length).to eq(3)
+          expect(result[0].class).to eq(SRT::File)
+          expect(result[1].class).to eq(SRT::File)
+          expect(result[2].class).to eq(SRT::File)
         end
 
         it "should let subtitles start at sequence number #1 in all three files" do
-          result[0].lines.first.sequence.should eq(1)
-          result[1].lines.first.sequence.should eq(1)
-          result[2].lines.first.sequence.should eq(1)
+          expect(result[0].lines.first.sequence).to eq(1)
+          expect(result[1].lines.first.sequence).to eq(1)
+          expect(result[2].lines.first.sequence).to eq(1)
         end
 
         it "should put 176 subtitles in the first file" do
-          result[0].lines.length.should eq(176)
-          result[0].lines.last.sequence.should eq(176)
+          expect(result[0].lines.length).to eq(176)
+          expect(result[0].lines.last.sequence).to eq(176)
         end
 
         it "should put 213 subtitles in the second file" do
-          result[1].lines.length.should eq(213)
-          result[1].lines.last.sequence.should eq(213)
+          expect(result[1].lines.length).to eq(213)
+          expect(result[1].lines.last.sequence).to eq(213)
         end
 
         it "should put 212 subtitles in the third file" do
-          result[2].lines.length.should eq(212)
-          result[2].lines.last.sequence.should eq(212)
+          expect(result[2].lines.length).to eq(212)
+          expect(result[2].lines.last.sequence).to eq(212)
         end
       end
 
@@ -244,9 +244,9 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :every => "00:00:01,000" ) }
 
         it "should return an array containing two SRT::File instances, ignoring :every" do
-          result.length.should eq(2)
-          result[0].class.should eq(SRT::File)
-          result[1].class.should eq(SRT::File)
+          expect(result.length).to eq(2)
+          expect(result[0].class).to eq(SRT::File)
+          expect(result[1].class).to eq(SRT::File)
         end
       end
 
@@ -254,9 +254,9 @@ describe SRT::File do
         let(:result) { file.split( :every => "00:05:00,000" ) }
 
         it "should return an array containing nine SRT::File instances" do
-          result.length.should eq(9)
+          expect(result.length).to eq(9)
           (0...result.count).each do |n|
-            result[n].class.should eq(SRT::File)
+            expect(result[n].class).to eq(SRT::File)
           end
         end
       end
@@ -265,8 +265,8 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :renumber => false ) }
 
         it "sequence for the last line of first part should be the sequence for the first line of second part" do
-          result[0].lines.last.text.should == result[1].lines.first.text
-          result[0].lines.last.sequence.should == result[1].lines.first.sequence
+          expect(result[0].lines.last.text).to eq(result[1].lines.first.text)
+          expect(result[0].lines.last.sequence).to eq(result[1].lines.first.sequence)
         end
       end
 
@@ -274,12 +274,12 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :renumber => true ) }
 
         it "first line of second part's number should be one" do
-          result[1].lines.first.sequence.should == 1
+          expect(result[1].lines.first.sequence).to eq(1)
         end
 
         it "sequence for the last line of first part should have different number than the sequence for the first line of second part" do
-          result[0].lines.last.text.should == result[1].lines.first.text
-          result[0].lines.last.sequence.should_not == result[1].lines.first.sequence
+          expect(result[0].lines.last.text).to eq(result[1].lines.first.text)
+          expect(result[0].lines.last.sequence).not_to eq(result[1].lines.first.sequence)
         end
       end
 
@@ -287,8 +287,8 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :timeshift => false ) }
 
         it "time for last line of first part should be the time for first line of second part" do
-          result[0].lines.last.text.should == result[1].lines.first.text
-          result[0].lines.last.time_str.should == result[1].lines.first.time_str
+          expect(result[0].lines.last.text).to eq(result[1].lines.first.text)
+          expect(result[0].lines.last.time_str).to eq(result[1].lines.first.time_str)
         end
       end
 
@@ -296,12 +296,12 @@ describe SRT::File do
         let(:result) { file.split( :at => "00:19:24,500", :timeshift => true ) }
 
         it "start_time of first line in second part should be 0" do
-          result[1].lines.first.start_time.should == 0
+          expect(result[1].lines.first.start_time).to eq(0)
         end
 
         it "time for last line of first part should not be the time for first line of second part" do
-          result[0].lines.last.text.should == result[1].lines.first.text
-          result[0].lines.last.time_str.should_not == result[1].lines.first.time_str
+          expect(result[0].lines.last.text).to eq(result[1].lines.first.text)
+          expect(result[0].lines.last.time_str).not_to eq(result[1].lines.first.time_str)
         end
       end
     end
@@ -315,11 +315,11 @@ describe SRT::File do
         before { file.timeshift({ :all => "+2.5s" }) }
 
         it "should have timecodes shifted forward by 2.5s for subtitle #24" do
-          file.lines[23].time_str.should eq("00:01:59,291 --> 00:02:00,815")
+          expect(file.lines[23].time_str).to eq("00:01:59,291 --> 00:02:00,815")
         end
 
         it "should have timecodes shifted forward by 2.5s for subtitle #43" do
-          file.lines[42].time_str.should eq("00:03:46,164 --> 00:03:47,631")
+          expect(file.lines[42].time_str).to eq("00:03:46,164 --> 00:03:47,631")
         end
       end
 
@@ -327,11 +327,11 @@ describe SRT::File do
         before { file.timeshift({ "25fps" => "23.976fps" }) }
 
         it "should have correctly scaled timecodes for subtitle #24" do
-          file.lines[23].time_str.should eq("00:01:52,007 --> 00:01:53,469")
+          expect(file.lines[23].time_str).to eq("00:01:52,007 --> 00:01:53,469")
         end
 
         it "should have correctly scaled timecodes for subtitle #43" do
-          file.lines[42].time_str.should eq("00:03:34,503 --> 00:03:35,910")
+          expect(file.lines[42].time_str).to eq("00:03:34,503 --> 00:03:35,910")
         end
       end
 
@@ -339,11 +339,11 @@ describe SRT::File do
         before { file.timeshift({ "#24" => "00:03:53,582", "#42" => "00:04:24,656" }) }
 
         it "should have shifted timecodes for subtitle #24" do
-          file.lines[23].time_str.should eq("00:03:53,582 --> 00:03:54,042")
+          expect(file.lines[23].time_str).to eq("00:03:53,582 --> 00:03:54,042")
         end
 
         it "should have differently shifted timecodes for subtitle #43" do
-          file.lines[41].time_str.should eq("00:04:24,656 --> 00:04:25,298")
+          expect(file.lines[41].time_str).to eq("00:04:24,656 --> 00:04:25,298")
         end
       end
 
@@ -351,11 +351,11 @@ describe SRT::File do
         before { file.timeshift({ 180 => "+1s", 264 => "+1.5s" }) }
 
         it "should have shifted by +1s at 180 seconds" do
-          file.lines[23].time_str.should eq("00:01:57,415 --> 00:01:58,948")
+          expect(file.lines[23].time_str).to eq("00:01:57,415 --> 00:01:58,948")
         end
 
         it "should have shifted by +1.5s at 264 seconds" do
-          file.lines[41].time_str.should eq("00:03:40,997 --> 00:03:43,136")
+          expect(file.lines[41].time_str).to eq("00:03:40,997 --> 00:03:43,136")
         end
       end
     end
@@ -367,7 +367,7 @@ describe SRT::File do
         before { file.timeshift({ :all => "-2.7m" }) }
 
         it "should have dumped 16 lines with now negative timecodes, leaving 1107" do
-          file.lines.size.should eq(1107)
+          expect(file.lines.size).to eq(1107)
         end
       end
 
@@ -375,7 +375,7 @@ describe SRT::File do
         before { file.timeshift({ "00:03:25,430" => "00:00:44,200", "01:49:29,980" => "01:46:35,600" }) }
 
         it "should have dumped 16 lines with now negative timecodes, leaving 1107" do
-          file.lines.size.should eq(1107)
+          expect(file.lines.size).to eq(1107)
         end
       end
     end
@@ -402,7 +402,7 @@ you're a machine.
 00:00:07,014 --> 00:00:08,003
 The robot.
 END
-          file.to_s.should eq(OUTPUT)
+          expect(file.to_s).to eq(OUTPUT)
         end
       end
     end
@@ -432,7 +432,7 @@ you're a machine.
 00:00:07.014 --> 00:00:08.003
 The robot.
 END
-          file.to_webvtt.should eq(OUTPUT_WEBVTT)
+          expect(file.to_webvtt).to eq(OUTPUT_WEBVTT)
         end
       end
     end

--- a/spec/line_spec.rb
+++ b/spec/line_spec.rb
@@ -6,7 +6,7 @@ describe SRT::Line do
     let(:line) { SRT::Line.new }
 
     it "should create an empty subtitle" do
-      line.should be_empty
+      expect(line).to be_empty
     end
   end
 
@@ -19,7 +19,7 @@ describe SRT::Line do
     end
 
     it "should produce timecodes that match the internal float values" do
-      line.time_str.should eq("00:03:44,200 --> 00:04:04,578")
+      expect(line.time_str).to eq("00:03:44,200 --> 00:04:04,578")
     end
   end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -6,33 +6,33 @@ describe SRT::Parser do
 
   describe ".id" do
     it "should convert the id string (#[id]) to an int representing the sequence number" do
-      subject.id("#317").should eq(317)
+      expect(subject.id("#317")).to eq(317)
     end
   end
 
   describe ".timecode" do
     it "should convert the SRT timecode format to a float representing seconds" do
-      subject.timecode("01:03:44,200").should eq(3824.2)
+      expect(subject.timecode("01:03:44,200")).to eq(3824.2)
     end
   end
 
   describe ".timespan" do
     it "should convert a timespan string ([+|-][amount][h|m|s|ms]) to a float representing seconds" do
-      subject.timespan("-3.5m").should eq(-210)
+      expect(subject.timespan("-3.5m")).to eq(-210)
     end
 
     it "should convert a timespan string ([+|-][amount][h|m|s|ms]) to a float representing seconds" do
-      subject.timespan("-1s").should eq(-1)
+      expect(subject.timespan("-1s")).to eq(-1)
     end
 
     it "should convert a timespan string ([+|-][amount][h|m|s|ms]) to a float representing seconds" do
-      subject.timespan("100ms").should eq(0.1)
+      expect(subject.timespan("100ms")).to eq(0.1)
     end
   end
 
   describe ".parse_framerate" do
     it "should convert a framerate string ([number]fps) to a float representing seconds" do
-      subject.framerate("23.976fps").should eq(23.976)
+      expect(subject.framerate("23.976fps")).to eq(23.976)
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.6 with the following command:
    transpec
- 84 conversions
  from: obj.should
    to: expect(obj).to
- 10 conversions
  from: == expected
    to: eq(expected)
- 4 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 1 conversion
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
