### PR TITLE
change timecode parser to include period as a separator 

### DIFF
--- a/lib/srt/parser.rb
+++ b/lib/srt/parser.rb
@@ -12,7 +12,7 @@ module SRT
       end
 
       def timecode(timecode_string)
-        mres = timecode_string.match(/(?<h>\d+):(?<m>\d+):(?<s>\d+),(?<ms>\d+)/)
+        mres = timecode_string.match(/(?<h>\d+):(?<m>\d+):(?<s>\d+)[,.](?<ms>\d+)/)
         mres ? "#{mres["h"].to_i * 3600 + mres["m"].to_i * 60 + mres["s"].to_i}.#{mres["ms"]}".to_f : nil
       end
 


### PR DESCRIPTION
I don't know if it is useful to others as I run into such a situation that some srt file take period as separator between second and millisecond in timecode.