### PR TITLE
fix MPEGTS timestamp value used on some players like iOS players

### DIFF
--- a/lib/srt/file.rb
+++ b/lib/srt/file.rb
@@ -215,7 +215,7 @@ module SRT
     def to_webvtt
       header = <<eos
 WEBVTT
-X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000
+X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
 
 eos
       header + to_s(:webvtt_time_str)

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -416,7 +416,7 @@ END
         it "should produce the exactly correct output" do
           OUTPUT_WEBVTT =<<END
 WEBVTT
-X-TIMESTAMP-MAP=MPEGTS:0,LOCAL:00:00:00.000
+X-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000
 
 1
 00:00:02.110 --> 00:00:04.578


### PR DESCRIPTION
Some players use the MPEGTS timestamp value as a baseline for text exhibition and with the '0' value the subtitle suffer a "drift".
According with the [documentation](https://tools.ietf.org/html/draft-pantos-http-live-streaming-12#section-4) this value should not be 0 to work on those players, like iOS players.
For the players which only parse the values on start/end times this value doesn't matter.