### PR TITLE
Fix fps scaling

### DIFF
--- a/lib/srt/file.rb
+++ b/lib/srt/file.rb
@@ -168,10 +168,10 @@ module SRT
             line.end_time += seconds
           end
         elsif (original_framerate = Parser.framerate(options.keys[0])) && (target_framerate = Parser.framerate(options.values[0]))
-          ratio = target_framerate / original_framerate
+          time_ratio = original_framerate / target_framerate
           lines.each do |line|
-            line.start_time *= ratio
-            line.end_time *= ratio
+            line.start_time *= time_ratio
+            line.end_time *= time_ratio
           end
         end
       elsif options.length == 2

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -333,11 +333,11 @@ describe SRT::File do
         before { file.timeshift({ "25fps" => "23.976fps" }) }
 
         it "should have correctly scaled timecodes for subtitle #24" do
-          expect(file.lines[23].time_str).to eq("00:01:52,007 --> 00:01:53,469")
+          expect(file.lines[23].time_str).to eq("00:02:01,779 --> 00:02:03,368")
         end
 
         it "should have correctly scaled timecodes for subtitle #43" do
-          expect(file.lines[42].time_str).to eq("00:03:34,503 --> 00:03:35,910")
+          expect(file.lines[42].time_str).to eq("00:03:53,217 --> 00:03:54,746")
         end
       end
 


### PR DESCRIPTION
The original code calculates `ratio = target_framerate / original_framerate` and multiplies sub times by `ratio`, but this is not the ratio between target times and original times — it's the inverse! The result is a scaling from `target_framerate` to `original_framerate`, which is backwards. The test spec is also incorrect.

This PR fixes the implementation and tests.