### PR TITLE
Add File.has_sequence_error?

### DIFF
--- a/lib/srt/file.rb
+++ b/lib/srt/file.rb
@@ -209,6 +209,20 @@ module SRT
       end
     end
 
+    def has_sequence_error?
+      sequence = lines.map { |line| line.sequence }
+      sequence_error_after = nil
+
+      sequence.each_cons(2) { |x,y|
+        if y - x != 1
+          sequence_error_after = x
+          break
+        end
+      }
+
+      "Sequence error after #{sequence_error_after}" if sequence_error_after
+    end
+
     def to_s(time_str_function=:time_str)
       lines.map { |l| l.to_s(time_str_function) }.join("\n")
     end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -313,6 +313,35 @@ describe SRT::File do
     end
   end
 
+  describe "has_sequence_error?" do
+    context "when sequence is ok" do
+      let(:file1) { SRT::File.parse(File.open("./spec/fixtures/blackswan-part1.srt")) }
+      let(:file2) { SRT::File.parse(File.open("./spec/fixtures/bsg-s01e01.srt")) }
+      let(:file3) { SRT::File.parse(File.open("./spec/fixtures/blackswan-part2.srt")) }
+      it "should return nil" do
+        expect(file1.has_sequence_error?).to eq nil
+        expect(file2.has_sequence_error?).to eq nil
+        expect(file3.has_sequence_error?).to eq nil
+      end
+    end
+
+    context "when sequence is non-consecutive" do
+      let(:file) { SRT::File.parse(File.open("./spec/fixtures/broken_sequence.srt")) }
+
+      it "should return a useful error message about the sequence" do
+        expect(file.has_sequence_error?).to eq("Sequence error after 1")
+      end
+    end
+
+    context "when there are unexpected blank lines" do
+      let(:file) { SRT::File.parse(File.open("./spec/fixtures/unexpected_blanks.srt")) }
+
+      it "should return a useful error message about the sequence" do
+        expect(file.has_sequence_error?).to eq("Sequence error after 3")
+      end
+    end
+  end
+
   describe "#timeshift" do
     context "when calling it on a properly formatted BSG SRT file" do
       let(:file) { SRT::File.parse(File.open("./spec/fixtures/bsg-s01e01.srt")) }

--- a/spec/fixtures/broken_sequence.srt
+++ b/spec/fixtures/broken_sequence.srt
@@ -1,0 +1,13 @@
+1
+00:00:02,110 --> 00:00:04,578
+<i>(male narrator) Previously
+on Battlestar Galactica.</i>
+
+1
+00:00:05,313 --> 00:00:06,871
+Now you're telling me
+you're a machine.
+
+3
+00:00:07,014 --> 00:00:08,003
+The robot.

--- a/spec/fixtures/unexpected_blanks.srt
+++ b/spec/fixtures/unexpected_blanks.srt
@@ -1,0 +1,14 @@
+1
+00:00:02,110 --> 00:00:04,578
+<i>(male narrator) Previously
+on Battlestar Galactica.</i>
+
+2
+00:00:05,313 --> 00:00:06,871
+Now you're telling me
+
+3
+00:00:07,014 --> 00:00:08,003
+The robot.
+
+you're a machine.


### PR DESCRIPTION
By checking the sequnce is in order, we can catch sequence
numbering errors & stray blank lines in a .srt file.